### PR TITLE
Allow shell to be changed via config.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,8 @@ pub struct Config
     /// Whether messages on the standard error streams emitted during test runs
     /// should always be shown.
     pub always_show_stderr: bool,
+    /// Which shell to use (defaults to 'bash').
+    pub shell: String,
 }
 
 /// A function which can dynamically define newly used variables in a test.
@@ -151,6 +153,7 @@ impl Default for Config
             always_show_stderr: false,
             truncate_output_context_to_number_of_lines: Some(DEFAULT_MAX_OUTPUT_CONTEXT_LINE_COUNT),
             extra_executable_search_paths,
+            shell: "bash".to_string(),
         }
     }
 }

--- a/src/run/legacy_test_evaluator.rs
+++ b/src/run/legacy_test_evaluator.rs
@@ -7,8 +7,6 @@ use crate::{parse, vars};
 
 use std;
 
-const SHELL: &'static str = "bash";
-
 pub struct TestEvaluator
 {
     pub invocation: Invocation,
@@ -40,7 +38,7 @@ impl TestEvaluator
             Err(e) => match e.kind() {
                 std::io::ErrorKind::NotFound => {
                     return TestResultKind::Error(
-                        format!("shell '{}' does not exist", SHELL).into(),
+                        format!("shell '{}' does not exist", &config.shell).into(),
                     );
                 },
                 _ => return TestResultKind::Error(e.into()),
@@ -73,7 +71,7 @@ impl TestEvaluator
 
         let command_line: String = vars::resolve::invocation(&self.invocation, &config, &mut variables);
 
-        let mut cmd = process::Command::new("bash");
+        let mut cmd = process::Command::new(&config.shell);
         cmd.args(&["-c", &command_line]);
 
         if let Ok(current_exe) = env::current_exe() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -14,4 +14,14 @@ fn integration_tests() {
             config.add_extension(ext);
         }
     }).expect("unit test(s) failed");
+
+    // Now run the tests again but use a custom shell instead.
+    run::tests(lit::event_handler::Default::default(), |config| {
+        config.add_search_path(format!("{}/integration-tests", CRATE_PATH));
+        for ext in lit::INTEGRATION_TEST_FILE_EXTENSIONS {
+            config.add_extension(ext);
+        }
+
+        config.shell = "sh".to_string();
+    }).expect("unit test(s) failed");
 }


### PR DESCRIPTION
This commit allows me (and others!) to change which shell to use to run the tests via the `config`. This is useful for platforms that do not have the default shell, `bash`, present.

To test this I decided that if the `lit` crate is happy to rely on `bash`, it makes sense that `sh` would also be present. So I added an additional run of the integration tests using `sh` to prove that it works.