### PR TITLE
feat(resolve): resolve constants on check too

### DIFF
--- a/integration-tests/single-check-with-variable.sh
+++ b/integration-tests/single-check-with-variable.sh
@@ -1,0 +1,4 @@
+# RUN: sh @file
+
+# CHECK: hello @file
+echo hello $0

--- a/src/model.rs
+++ b/src/model.rs
@@ -53,6 +53,7 @@ pub struct TextPattern {
 /// A component in a text pattern.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PatternComponent {
+    Constant(String),
     Text(String),
     Variable(String),
     Regex(String),
@@ -198,6 +199,7 @@ impl fmt::Display for TextPattern {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         for component in self.components.iter() {
             match *component {
+                PatternComponent::Constant(ref constant) => write!(fmt, "@{}", constant)?,
                 PatternComponent::Text(ref text) => write!(fmt, "{}", text)?,
                 PatternComponent::Variable(ref name) => write!(fmt, "$${}", name)?,
                 PatternComponent::Regex(ref regex) => write!(fmt, "[[{}]]", regex)?,

--- a/src/vars/resolve.rs
+++ b/src/vars/resolve.rs
@@ -25,7 +25,7 @@ pub fn text_pattern(pattern: &TextPattern, config: &Config,
                     variables: &mut Variables) -> Regex {
     let regex_parts: Vec<_> = pattern.components.iter().map(|comp| match *comp {
         PatternComponent::Text(ref text) => regex::escape(text),
-        PatternComponent::Variable(ref name) => {
+        PatternComponent::Constant(ref name) | PatternComponent::Variable(ref name) => {
             // FIXME: proper error handling.
             let value = config.lookup_variable(name, variables);
 


### PR DESCRIPTION
Hi @dylanmckay 

Like @lukaspustina, I find this crate a holy tool that I will certainly over use ! 🙏
Here is my attempt fixing the `CHECK @variable` issue (https://github.com/dylanmckay/lit/issues/5)
 
<br>
<br>
<br>
<br>


###### NOTE: `#[cfg(tes)]`

It seems like there is a typo on `#[cfg(test)]` in [src/parse.rs](src/parse.rs) preventing the unit tests to run :

https://github.com/dylanmckay/lit/blob/652ee63fffe1e825c6c2eb6d5d1de800d2241a74/src/parse.rs#L180

Activating it made the compiler angry so I changed the tests a bit...
I hope that it still follows the specs you have in mind (:

<br>
<br>
<br>
<br>


###### NOOTE: rustfmt ?

It seems like you are not using [the default code formatter](https://github.com/rust-lang/rustfmt) as I had to manually disable it to have that "minimal" PR.  
Are you against the idea of using it on this project ?

<br>
<br>
<br>
<br>

---

I have to thank lord @sheredom for [his inspirational article](https://www.duskborn.com/posts/rust-lit/) that convinced me, a lvl 0 Rust-y 🦀, to take a closer look at this testing tool beauty 😏 

---

Fixes https://github.com/dylanmckay/lit/issues/5