### PR TITLE
Allow the specification of env variables for tests.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,8 @@ pub struct Config
     pub always_show_stderr: bool,
     /// Which shell to use (defaults to 'bash').
     pub shell: String,
+    /// List of environment variables to be used on test invocation.
+    pub env_variables: HashMap<String, String>,
 }
 
 /// A function which can dynamically define newly used variables in a test.
@@ -154,6 +156,7 @@ impl Default for Config
             truncate_output_context_to_number_of_lines: Some(DEFAULT_MAX_OUTPUT_CONTEXT_LINE_COUNT),
             extra_executable_search_paths,
             shell: "bash".to_string(),
+            env_variables: HashMap::default(),
         }
     }
 }

--- a/src/run/test_evaluator.rs
+++ b/src/run/test_evaluator.rs
@@ -143,6 +143,7 @@ fn build_command(invocation: &Invocation,
 
     let mut cmd = process::Command::new(&config.shell);
     cmd.args(&["-c", &command_line]);
+    cmd.envs(&config.env_variables);
 
     if !config.extra_executable_search_paths.is_empty() {
         let os_path_separator = if cfg!(windows) { ";" } else { ":" };


### PR DESCRIPTION
This PR adds the possibility to specify environment variables that will be passed to the test shell command.  