### PR TITLE
Make TestResult public.

### DIFF
--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -4,7 +4,7 @@
 
 pub use self::default::EventHandler as Default;
 
-use crate::{Config, model::{TestResult}};
+pub use crate::{Config, model::{TestResult}};
 
 mod default;
 


### PR DESCRIPTION
This change is necessary to implement a custom `EventHandler` as `EventHandler` takes `TestResult` as a parameter to one of its functions.